### PR TITLE
Feature/add ginkgo and mock providers

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,10 +1,9 @@
 name: Run Unit Tests
 
 on:
-  push: {}
   pull_request:
     branches:
-        - master
+      - master
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.0
 	github.com/onsi/gomega v1.17.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.8.3
 )

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/providers/ginkgoprovider/provider.go
+++ b/providers/ginkgoprovider/provider.go
@@ -1,0 +1,53 @@
+package ginkgoprovider
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/myhelix/contextlogger/providers"
+	"github.com/myhelix/contextlogger/providers/chaining"
+	"github.com/onsi/ginkgo/v2"
+)
+
+func LogProvider(nextProvider providers.LogProvider) providers.LogProvider {
+	return &provider{
+		Writer:      ginkgo.GinkgoWriter,
+		LogProvider: chaining.LogProvider(nextProvider),
+	}
+}
+
+type provider struct {
+	io.Writer
+	providers.LogProvider
+}
+
+func (p *provider) Error(ctx context.Context, report bool, args ...interface{}) {
+	fmt.Fprintln(p, args...)
+	p.LogProvider.Error(ctx, report, args...)
+}
+
+func (p *provider) Warn(ctx context.Context, report bool, args ...interface{}) {
+	fmt.Fprintln(p, args...)
+	p.LogProvider.Warn(ctx, report, args...)
+}
+
+func (p *provider) Info(ctx context.Context, report bool, args ...interface{}) {
+	fmt.Fprintln(p, args...)
+	p.LogProvider.Info(ctx, report, args...)
+}
+
+func (p *provider) Debug(ctx context.Context, report bool, args ...interface{}) {
+	fmt.Fprintln(p, args...)
+	p.LogProvider.Debug(ctx, report, args...)
+}
+
+func (p *provider) Record(ctx context.Context, metrics map[string]interface{}) {
+	fmt.Fprintln(p, metrics)
+	p.LogProvider.Record(ctx, metrics)
+}
+
+func (p *provider) RecordEvent(ctx context.Context, eventName string, metrics map[string]interface{}) {
+	fmt.Fprintln(p, eventName, metrics)
+	p.LogProvider.RecordEvent(ctx, eventName, metrics)
+}

--- a/providers/mockprovider/provider.go
+++ b/providers/mockprovider/provider.go
@@ -8,46 +8,46 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func LogProvider(nextProvider providers.LogProvider) *MockProvider {
-	return &MockProvider{LogProvider: chaining.LogProvider(nextProvider)}
+func LogProvider(nextProvider providers.LogProvider) *provider {
+	return &provider{LogProvider: chaining.LogProvider(nextProvider)}
 }
 
-type MockProvider struct {
+type provider struct {
 	mock.Mock
 	providers.LogProvider
 }
 
-func (p *MockProvider) Error(ctx context.Context, report bool, args ...interface{}) {
+func (p *provider) Error(ctx context.Context, report bool, args ...interface{}) {
 	p.Called(ctx, report, args)
 	p.LogProvider.Error(ctx, report, args...)
 }
 
-func (p *MockProvider) Warn(ctx context.Context, report bool, args ...interface{}) {
+func (p *provider) Warn(ctx context.Context, report bool, args ...interface{}) {
 	p.Called(ctx, report, args)
 	p.LogProvider.Warn(ctx, report, args...)
 }
 
-func (p *MockProvider) Info(ctx context.Context, report bool, args ...interface{}) {
+func (p *provider) Info(ctx context.Context, report bool, args ...interface{}) {
 	p.Called(ctx, report, args)
 	p.LogProvider.Info(ctx, report, args...)
 }
 
-func (p *MockProvider) Debug(ctx context.Context, report bool, args ...interface{}) {
+func (p *provider) Debug(ctx context.Context, report bool, args ...interface{}) {
 	p.Called(ctx, report, args)
 	p.LogProvider.Debug(ctx, report, args...)
 }
 
-func (p *MockProvider) Record(ctx context.Context, metrics map[string]interface{}) {
+func (p *provider) Record(ctx context.Context, metrics map[string]interface{}) {
 	p.Called(ctx, metrics)
 	p.LogProvider.Record(ctx, metrics)
 }
 
-func (p *MockProvider) RecordEvent(ctx context.Context, eventName string, metrics map[string]interface{}) {
+func (p *provider) RecordEvent(ctx context.Context, eventName string, metrics map[string]interface{}) {
 	p.Called(ctx, eventName, metrics)
 	p.LogProvider.RecordEvent(ctx, eventName, metrics)
 }
 
-func (p *MockProvider) Wait() {
+func (p *provider) Wait() {
 	p.Called()
 	p.LogProvider.Wait()
 }

--- a/providers/mockprovider/provider.go
+++ b/providers/mockprovider/provider.go
@@ -1,0 +1,53 @@
+package mockprovider
+
+import (
+	"context"
+
+	"github.com/myhelix/contextlogger/providers"
+	"github.com/myhelix/contextlogger/providers/chaining"
+	"github.com/stretchr/testify/mock"
+)
+
+func LogProvider(nextProvider providers.LogProvider) *MockProvider {
+	return &MockProvider{LogProvider: chaining.LogProvider(nextProvider)}
+}
+
+type MockProvider struct {
+	mock.Mock
+	providers.LogProvider
+}
+
+func (p *MockProvider) Error(ctx context.Context, report bool, args ...interface{}) {
+	p.Called(ctx, report, args)
+	p.LogProvider.Error(ctx, report, args...)
+}
+
+func (p *MockProvider) Warn(ctx context.Context, report bool, args ...interface{}) {
+	p.Called(ctx, report, args)
+	p.LogProvider.Warn(ctx, report, args...)
+}
+
+func (p *MockProvider) Info(ctx context.Context, report bool, args ...interface{}) {
+	p.Called(ctx, report, args)
+	p.LogProvider.Info(ctx, report, args...)
+}
+
+func (p *MockProvider) Debug(ctx context.Context, report bool, args ...interface{}) {
+	p.Called(ctx, report, args)
+	p.LogProvider.Debug(ctx, report, args...)
+}
+
+func (p *MockProvider) Record(ctx context.Context, metrics map[string]interface{}) {
+	p.Called(ctx, metrics)
+	p.LogProvider.Record(ctx, metrics)
+}
+
+func (p *MockProvider) RecordEvent(ctx context.Context, eventName string, metrics map[string]interface{}) {
+	p.Called(ctx, eventName, metrics)
+	p.LogProvider.RecordEvent(ctx, eventName, metrics)
+}
+
+func (p *MockProvider) Wait() {
+	p.Called()
+	p.LogProvider.Wait()
+}


### PR DESCRIPTION
Add ginkgo and mock providers for improved unit test logging. 

1. `mockprovider`: For functions that convert `context.Context` into a `log.ContextLogger` using `log.FromContext(ctx)`, adding a mock log providers allows users to unit test that log functions are called.
2. `ginkgo`: Only write log statements on failed ginkgo tests using the `GingkoWriter`
